### PR TITLE
Config instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,29 +54,35 @@ If you use Ubuntu, you can use the following commands:
 
 ### Clone the HAT project
 
-Then, you will be able to clone the repository
+Then, you will be able to clone the repository:
 
     git clone https://github.com/Hub-of-all-Things/HAT2.0.git hat
 
 ### Database Setup
 
-You will need to set up a PostgreSQL database with the HAT2.0 schema, configure the project to use the database, compile and run it. You can do all that by executing the following script:
+You will need to set up a PostgreSQL database with the HAT2.0 schema, configure the project to use the database, and prepare it to be executed. You can do all that by executing the following script:
 
     ./deployment/deploy.sh
     
-The provided script executes all required commands to get the project running and can be configured through environment variables:
+The provided script executes all required commands to get the project running, and can be configured through environment variables. For example, you can run:
 
-- `DATABASE` - name of the database
-- `DBUSER` - database username
-- `DBPASS` - database user password
-- `HAT_OWNER` - HAT owner identity (DNS name/username)
+    ./deployment/deploy.sh -DATABASE=mynewHAT -DBUSER=mynewuser -DBPASS=mynewpass
+
+The following variables are available:
+
+- `DATABASE` - name of the database [default: hat20test]
+- `DBUSER` - database username [default: hat20test]
+- `DBPASS` - database user password [default: pa55w0rd]
+- `HAT_OWNER` - HAT owner identity (DNS name/username) [default: bob@gmail.com]
 - `HAT_OWNER_ID` - HAT owner GUID
-- `HAT_OWNER_NAME` - HAT owner name
-- `HAT_OWNER_PASSWORD` - HAT owner login password
-- `HAT_PLATFORM` - HAT platform identity
+- `HAT_OWNER_NAME` - HAT owner name [default: Bob]
+- `HAT_OWNER_PASSWORD` - HAT owner login password [default: pa55w0rd]
+- `HAT_PLATFORM` - HAT platform identity [default: hatdex.org]
 - `HAT_PLATFORM_ID` - HAT platform GUID
-- `HAT_PLATFORM_NAME` - HAT platform name
+- `HAT_PLATFORM_NAME` - HAT platform name [default: hatdex]
 - `HAT_PLATFORM_PASSWORD_HASH` - BCrypt-hashed HAT platform password for platform-management operations (application account creation only)
+
+If you do not specify those variables, take a look at the deploy.sh script to see the default values.
 
 ### Run the project!
 Execute the following command:
@@ -93,12 +99,21 @@ Here we list common problems you may have encountered in this process.
 
 #### 1. Database peer authentication failed at the top
 
-Your PostgreSQL installation may be configured to use peer authentication, but this method is only supported on local connections.
+You may have seen an error message similar to `psql: FATAL:  Peer authentication failed for user "hat20"`.
 
-[This thread in Stack Overflow](http://stackoverflow.com/questions/18664074/getting-error-peer-authentication-failed-for-user-postgres-when-trying-to-ge) explains how to modify your file `pg_hba.conf` to solve it.
+Your PostgreSQL installation is configured to use peer authentication, which means that the user in your operating system and postgres must be the same.
 
-If you are using an IP address other than 127.0.0.1, you can specify your network's IP range instead.
- 
+You can change it either to **md5** (password-based authentication) or **trust** (anyone who can connect to the server can access the database).
+
+[This thread in Stack Overflow](http://stackoverflow.com/questions/18664074/getting-error-peer-authentication-failed-for-user-postgres-when-trying-to-ge) explains in more detail your options and implications.
+
+You will need to edit the file `pg_hba.conf` (`/etc/postgresql/9.3/main/pg_hba.conf`, depending on your postgres version), and change the **method**. For example:
+
+    # TYPE  DATABASE        USER            ADDRESS                 METHOD
+    local   all             postgres                                md5
+    local   all             all                                     md5
+
+
 #### 2. Another program is already listening to port 8080
 
 You can specify another port or host directly in the run command. For example:

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -2,16 +2,19 @@
 
 DATABASE=${DATABASE:-"hat20test"}
 DBUSER=${DBUSER:-$DATABASE}
-DBPASS=${DBPASS:-""}
-
+DBPASS=${DBPASS:-"pa55w0rd"}
 
 # Create the DB
 # NOSUPERUSER NOCREATEDB NOCREATEROLE
 echo "Setting up database user and database"
 createuser -S -D -R -e $DBUSER
 createdb $DATABASE -O $DBUSER
+psql $DATABASE -c "ALTER USER $DBUSER WITH PASSWORD '$DBPASS';"
 psql $DATABASE -c 'CREATE EXTENSION "uuid-ossp";'
 psql $DATABASE -c 'CREATE EXTENSION "pgcrypto";'
+export PGPASSWORD="$DBPASS" #use the given password for the next psql commands
+
+# Execute HAT-V2.0 SQL script
 psql $DATABASE -U$DBUSER < src/sql/HAT-V2.0.sql
 
 # Setup db config for the project
@@ -53,8 +56,8 @@ psql $DATABASE -U$DBUSER < src/sql/relationships.sql
 psql $DATABASE -U$DBUSER < src/sql/properties.sql
 psql $DATABASE -U$DBUSER < src/sql/collections.sql
 
-# Rebuild and run the project
-echo "Compiling and running the project"
+# Prepare the project to be executed in-place
+echo "Preparing the project to be executed"
 #sbt clean
 #sbt compile
-sbt run
+sbt stage


### PR DESCRIPTION
Changed password setup in deploy script, and adapted it to the docker changes

 - The password for the user of the test database was empty by default, but md5 authentication does not allow empty passwords. Now, the default password is pa55w0rd.
 - The environment variable DBPASS now updates the database user password.
 - Some users need to use options in `sbt run` (for example, applicationHost and Port), so instead of running the project, we just stage it in the end of the script
 - Updated readme accordingly