### PR TITLE
supporting kubernetes linking

### DIFF
--- a/deployment/docker/database.conf.template
+++ b/deployment/docker/database.conf.template
@@ -4,7 +4,7 @@ devdb = {
     databaseName = ${?POSTGRES_DB}
     user = ${?POSTGRES_USER}
     password = ${?POSTGRES_PASSWORD}
-    serverName = hat-postgres-${?HAT_OWNER_NAME}
+    serverName = ${?POSTGRES_HOST}
   }
   numThreads = 3
 }

--- a/deployment/docker/docker-test-images.sh
+++ b/deployment/docker/docker-test-images.sh
@@ -12,6 +12,7 @@ for name in jorge nichola junior; do
     -e "POSTGRES_PASSWORD=$name"\
     -e "POSTGRES_USER=$name"\
     -e "POSTGRES_DB=$name"\
+    -e "POSTGRES_HOST=hat-postgres-$name"\
     -e "HAT_OWNER=$name@gmail.com"\
     -e "HAT_OWNER_NAME=$name"\
     -e "HAT_OWNER_PASSWORD=$name"\
@@ -24,6 +25,7 @@ for name in jorge nichola junior; do
     -e "POSTGRES_PASSWORD=$name"\
     -e "POSTGRES_USER=$name"\
     -e "POSTGRES_DB=$name"\
+    -e "POSTGRES_HOST=hat-postgres-$name"\
     -e "HAT_OWNER=$name@gmail.com"\
     -e "HAT_OWNER_NAME=$name"\
     -e "HAT_OWNER_PASSWORD=$name"\


### PR DESCRIPTION
Docker links containers together by establishing a tunnel between both containers and setting the /etc/hosts file to contain the hostname of the PG container.

In kubernetes, containers can be launched inside the same pod. Containers inside the same pod can access each other ports so the servername is not necessarily the name of the container. 