### PR TITLE
Enable support for Cordova and Electron applications

### DIFF
--- a/hat/conf/application.conf
+++ b/hat/conf/application.conf
@@ -70,6 +70,10 @@ play.filters {
       "X-Requested-With",
       "X-Auth-Token"]
     preflightMaxAge = 3 days
+
+    # Enable support for Cordova and Electron Applications
+    # ref https://github.com/playframework/playframework/issues/5193
+    serveForbiddenOrigins = true
   }
 
   csrf.header.bypassHeaders {


### PR DESCRIPTION
**Problem Statement**
When a Cordova Mobile application make a Javascript call to HAT endpoints, (with the correct headers, tokens and credentials), a 403 Forbidden status is always returned by HAT.

**Detailed Description**
The above issue has been reported before
https://github.com/playframework/playframework/issues/5193

The cause is during a call to a webservice, Cordova would set the `Origin` header to `file://`. And the CORSFilter in the Play Framework would reject it. This observation is further tested/verified with Postman or curl calls.

**Resolution**
Play Framework has resolved this issue by introducing the setting `play.filters.cors.serveForbiddenOrigins`. The default value is false.

This PR adds the above setting and sets the value to true.

**Extended Impact**
Web literature seems to suggest that Electron applications would encounter the same error.

***
HAT DCO
Signed-off-by: Terry Lee <terry.lee@nogginasia.com>