### PR TITLE
Updated instagram feed mapper to read posts from Instagram API v2

### DIFF
--- a/hat/app/org/hatdex/hat/she/mappers/InstagramMappers.scala
+++ b/hat/app/org/hatdex/hat/she/mappers/InstagramMappers.scala
@@ -3,7 +3,7 @@ package org.hatdex.hat.she.mappers
 import java.util.UUID
 
 import org.hatdex.hat.api.models.{ EndpointQuery, EndpointQueryFilter, FilterOperator, PropertyQuery }
-import org.hatdex.hat.api.models.applications.{ DataFeedItem, DataFeedItemContent, DataFeedItemLocation, DataFeedItemMedia, DataFeedItemTitle, LocationAddress, LocationGeo }
+import org.hatdex.hat.api.models.applications.{ DataFeedItem, DataFeedItemContent, DataFeedItemMedia, DataFeedItemTitle }
 import org.hatdex.hat.she.models.StaticDataValues
 import org.joda.time.DateTime
 import play.api.libs.json.{ JsError, JsNumber, JsObject, JsResult, JsSuccess, JsValue, Json, __ }
@@ -14,50 +14,33 @@ class InstagramMediaMapper extends DataEndpointMapper {
   override protected val dataDeduplicationField: Option[String] = Some("id")
 
   def dataQueries(fromDate: Option[DateTime], untilDate: Option[DateTime]): Seq[PropertyQuery] = {
-    val unixDateFilter = fromDate.flatMap { _ =>
-      Some(FilterOperator.Between(Json.toJson(fromDate.map(t => (t.getMillis / 1000).toString)), Json.toJson(untilDate.map(t => (t.getMillis / 1000).toString))))
-    }
-
     Seq(PropertyQuery(
-      List(EndpointQuery("instagram/feed", None,
-        unixDateFilter.map(f ⇒ Seq(EndpointQueryFilter("created_time", None, f))), None)), Some("created_time"), Some("descending"), None))
+      List(EndpointQuery("instagram/feed", None, dateFilter(fromDate, untilDate).map(f ⇒ Seq(EndpointQueryFilter("timestamp", None, f))), None)),
+      Some("timestamp"), Some("descending"), None))
   }
 
   def mapDataRecord(recordId: UUID, content: JsValue, tailRecordId: Option[UUID] = None, tailContent: Option[JsValue] = None): Try[DataFeedItem] = {
     for {
-      createdTime <- Try(new DateTime((content \ "created_time").as[String].toLong * 1000))
-      tags <- Try((content \ "tags").as[List[String]])
-      kind <- Try((content \ "type").as[String])
-      title <- Try(Some(DataFeedItemTitle("You posted", None, Some(kind))))
+      createdTime <- Try(new DateTime((content \ "timestamp").as[DateTime]))
+      description <- Try((content \ "caption").as[String])
+      kind <- Try((content \ "media_type").as[String])
+      title <- Try(Some(DataFeedItemTitle("You posted", None, Some(kind.toLowerCase))))
       feedItemContent <- Try(Some(DataFeedItemContent(
-        (content \ "caption" \ "text").asOpt[String],
+        Some(description),
         None,
         kind match {
-          case "image" =>
+          case "IMAGE" =>
             Some(Seq(DataFeedItemMedia(
-              (content \ "images" \ "thumbnail" \ "url").asOpt[String],
-              (content \ "images" \ "standard_resolution" \ "url").asOpt[String])))
-          case "carousel" =>
-            Some((content \ "carousel_media").as[Seq[JsObject]].map { imageInfo =>
-              DataFeedItemMedia(
-                (imageInfo \ "images" \ "thumbnail" \ "url").asOpt[String],
-                (imageInfo \ "images" \ "standard_resolution" \ "url").asOpt[String])
-            })
+              (content \ "media_url").asOpt[String],
+              (content \ "media_url").asOpt[String])))
           case _ => None
         },
         None)))
     } yield {
-      val location = Try(DataFeedItemLocation(
-        geo = (content \ "location").asOpt[JsObject]
-          .map(location =>
-            LocationGeo(
-              (location \ "longitude").as[Double],
-              (location \ "latitude").as[Double])),
-        address = (content \ "location" \ "street_address").asOpt[String]
-          .map(fullAddress => LocationAddress(None, None, Some(fullAddress), None, None)),
-        tags = None)).toOption
-
-      DataFeedItem("instagram", createdTime, tags, title, feedItemContent, location)
+      val regex = "#\\w+".r
+      val tags = regex.findAllIn(description).toList
+      logger.debug(s"Tags: $tags")
+      DataFeedItem("instagram", createdTime, tags, title, feedItemContent, None)
     }
   }
 }
@@ -66,7 +49,7 @@ class InstagramProfileStaticDataMapper extends StaticDataEndpointMapper {
   def dataQueries(): Seq[PropertyQuery] = {
     Seq(PropertyQuery(
       List(
-        EndpointQuery("instagram/profile", None, None, None)), Some("hat_updated_time"), Some("descending"), Some(1)))
+        EndpointQuery("instagram/profile", None, None, None)), Some("hat_created_time"), Some("descending"), Some(1)))
   }
 
   def mapDataRecord(recordId: UUID, content: JsValue, endpoint: String): Seq[StaticDataValues] = {
@@ -97,14 +80,10 @@ class InstagramProfileStaticDataMapper extends StaticDataEndpointMapper {
     val transformation = __.json.update(
       __.read[JsObject].map(profile => {
         logger.info(s"Trying to map profile: $profile")
-        val totalImagesUploaded = (profile \ "counts" \ "media").asOpt[JsNumber].getOrElse(JsNumber(0))
-        val totalFollowers = (profile \ "counts" \ "followed_by").asOpt[JsNumber].getOrElse(JsNumber(0))
-        val totalPeopleUsersFollows = (profile \ "counts" \ "follows").asOpt[JsNumber].getOrElse(JsNumber(0))
+        val totalImagesUploaded = (profile \ "media_count").asOpt[JsNumber].getOrElse(JsNumber(0))
 
         profile ++ JsObject(Map(
-          "media" -> totalImagesUploaded,
-          "follows" -> totalPeopleUsersFollows,
-          "followers" -> totalFollowers))
+          "media" -> totalImagesUploaded))
       }))
 
     rawData.transform(transformation)


### PR DESCRIPTION
Due to migration to v2 of Instagram's API, the data structures have changed. That necessitates updating of the relevant SHE feed mapper. 