### PR TITLE
DS-539 fix TypeUtils crash

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,7 @@ lazy val hat = project
       Library.Utils.playMemcached,
       Library.Utils.elasticacheClusterClient,
       Library.Utils.alpakkaAwsLambda,
+      Library.Utils.apacheCommonLang,
       Library.scalaGuice
     ),
     libraryDependencies := (buildEnv.value match {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -91,6 +91,7 @@ object Dependencies {
       val elasticacheClusterClient = "com.amazonaws" % "elasticache-java-cluster-client" % "1.1.1"
       val playMemcached = "com.github.mumoshu" %% "play2-memcached-play26" % "0.9.3" exclude("net.spy", "spymemcached")
       val alpakkaAwsLambda = "com.lightbend.akka" %% "akka-stream-alpakka-awslambda" % "0.20"
+      val apacheCommonLang = "org.apache.commons" % "commons-lang3" % "3.10"
     }
 
     object HATDeX {


### PR DESCRIPTION
Outdated Java 11 incompatible version of TypeUtils was being used in the project.

The fix removes transitive dependency on ApacheCommonLang library and explicitly updates it to the latest version 3.10.