### PR TITLE
DS-606 dependency setup

### DIFF
--- a/hat/app/org/hatdex/hat/api/service/applications/ApplicationExceptions.scala
+++ b/hat/app/org/hatdex/hat/api/service/applications/ApplicationExceptions.scala
@@ -1,0 +1,10 @@
+package org.hatdex.hat.api.service.applications
+
+object ApplicationExceptions {
+  abstract class HatApplicationManagementException(message: String, cause: Throwable = None.orNull) extends Exception(message, cause)
+
+  case class HatApplicationSetupException(appId: String, message: String, cause: Throwable = None.orNull)
+    extends HatApplicationManagementException(message, cause)
+  case class HatApplicationDependencyException(appId: String, message: String, cause: Throwable = None.orNull)
+    extends HatApplicationManagementException(message, cause)
+}

--- a/hat/app/org/hatdex/hat/she/mappers/DataEndpointMapper.scala
+++ b/hat/app/org/hatdex/hat/she/mappers/DataEndpointMapper.scala
@@ -110,10 +110,10 @@ trait DataEndpointMapper extends JodaWrites with JodaReads {
           s"- ${t.minusMinutes(1).toString("dd MMMM")}"
         }
         else {
-          s"- ${t.withZone(start.getZone).toString("dd MMMM HH:mm z")}"
+          s"- ${t.withZone(start.getZone).toString("dd MMMM HH:mm ZZZ")}"
         }
       case t if t.hourOfDay().get() == 0 ⇒ ""
-      case t                             ⇒ s"- ${t.withZone(start.getZone).toString("HH:mm z")}"
+      case t                             ⇒ s"- ${t.withZone(start.getZone).toString("HH:mm ZZZ")}"
     }
 
     (startString, endString)

--- a/hat/test/org/hatdex/hat/api/controllers/ApplicationsSpec.scala
+++ b/hat/test/org/hatdex/hat/api/controllers/ApplicationsSpec.scala
@@ -76,7 +76,7 @@ class ApplicationsSpec extends PlaySpecification with Mockito with ApplicationsS
       status(result) must equalTo(OK)
       contentAsJson(result).validate[Seq[HatApplication]].isSuccess must beTrue
       val apps = contentAsJson(result).as[Seq[HatApplication]]
-      apps.length must be equalTo 5
+      apps.length must be equalTo 8
       apps.find(_.application.id == notablesApp.id) must beSome
       apps.find(_.application.id == notablesAppDebitless.id) must beSome
       apps.find(_.application.id == notablesAppIncompatible.id) must beSome

--- a/hat/test/org/hatdex/hat/api/service/applications/ApplicationsServiceContext.scala
+++ b/hat/test/org/hatdex/hat/api/service/applications/ApplicationsServiceContext.scala
@@ -287,7 +287,8 @@ trait ApplicationsServiceContext extends HATTestContext {
     override def configure(): Unit = {
       bind[TrustedApplicationProvider].toInstance(new TestApplicationProvider(
         Seq(notablesApp, notablesAppDebitless, notablesAppIncompatibleUpdated,
-          notablesAppExternal, notablesAppExternalFailing, notablesAppDebitlessWithPlugDependency,
+          notablesAppExternal, notablesAppExternalFailing,
+          notablesAppDebitlessWithPlugDependency, notablesAppDebitlessWithInvalidDependency,
           plugApp)))
 
       bind[ApplicationStatusCheckService].toInstance(mockStatusChecker)

--- a/hat/test/org/hatdex/hat/api/service/applications/ApplicationsServiceContext.scala
+++ b/hat/test/org/hatdex/hat/api/service/applications/ApplicationsServiceContext.scala
@@ -221,6 +221,15 @@ trait ApplicationsServiceContext extends HATTestContext {
     permissions = notablesApp.permissions.copy(
       dataRetrieved = Some(notablesApp.permissions.dataRetrieved.get.copy(
         name = "notables-external-failing"))))
+  val notablesAppDebitlessWithPlugDependency = notablesAppDebitless.copy(
+    id = "notables-plug-dependency",
+    dependencies = Some(ApplicationDependencies(List("plug-app").toArray, List().toArray, List().toArray)))
+  val notablesAppDebitlessWithInvalidDependency = notablesAppDebitless.copy(
+    id = "notables-invalid-dependency",
+    dependencies = Some(ApplicationDependencies(List("invalid-id").toArray, List().toArray, List().toArray)))
+  val plugApp = notablesAppDebitless.copy(
+    id = "plug-app",
+    kind = ApplicationKind.DataPlug("http://dataplug.hat.org"))
 
   def withMockWsClient[T](block: WSClient => T): T = {
     Server.withRouterFromComponents() {
@@ -278,7 +287,8 @@ trait ApplicationsServiceContext extends HATTestContext {
     override def configure(): Unit = {
       bind[TrustedApplicationProvider].toInstance(new TestApplicationProvider(
         Seq(notablesApp, notablesAppDebitless, notablesAppIncompatibleUpdated,
-          notablesAppExternal, notablesAppExternalFailing)))
+          notablesAppExternal, notablesAppExternalFailing, notablesAppDebitlessWithPlugDependency,
+          plugApp)))
 
       bind[ApplicationStatusCheckService].toInstance(mockStatusChecker)
       bind[StatsReporter].toInstance(mockStatsReporter)

--- a/hat/test/org/hatdex/hat/api/service/applications/ApplicationsServiceContext.scala
+++ b/hat/test/org/hatdex/hat/api/service/applications/ApplicationsServiceContext.scala
@@ -188,6 +188,7 @@ trait ApplicationsServiceContext extends HATTestContext {
       info = appInfo,
       developer = developer,
       permissions = permissions,
+      dependencies = None,
       setup = setup,
       status = status)
 

--- a/hat/test/org/hatdex/hat/api/service/applications/ApplicationsServiceSpec.scala
+++ b/hat/test/org/hatdex/hat/api/service/applications/ApplicationsServiceSpec.scala
@@ -28,6 +28,7 @@ import com.mohiva.play.silhouette.api.crypto.Base64AuthenticatorEncoder
 import com.mohiva.play.silhouette.impl.authenticators.{ JWTRS256Authenticator, JWTRS256AuthenticatorSettings }
 import org.hatdex.hat.api.models.EndpointData
 import org.hatdex.hat.api.models.applications.{ ApplicationStatus, HatApplication, Version }
+import org.hatdex.hat.api.service.applications.ApplicationExceptions.{ HatApplicationDependencyException, HatApplicationSetupException }
 import org.hatdex.hat.api.service.richData.{ DataDebitService, RichDataService }
 import org.joda.time.DateTime
 import org.specs2.concurrent.ExecutionEnv
@@ -73,7 +74,7 @@ class ApplicationsServiceSpec(implicit ee: ExecutionEnv) extends PlaySpecificati
       val result = for {
         apps <- service.applicationStatus()
       } yield {
-        apps.length must be equalTo 5
+        apps.length must be equalTo 7
         apps.find(_.application.id == notablesApp.id) must beSome
         apps.find(_.application.id == notablesAppDebitless.id) must beSome
         apps.find(_.application.id == notablesAppIncompatible.id) must beSome
@@ -88,7 +89,7 @@ class ApplicationsServiceSpec(implicit ee: ExecutionEnv) extends PlaySpecificati
         _ ← service.setup(HatApplication(notablesApp, setup = false, enabled = false, active = false, None, None, None))
         apps ← service.applicationStatus()
       } yield {
-        apps.length must be equalTo 5
+        apps.length must be equalTo 7
         apps.find(_.application.id == notablesAppDebitless.id) must beSome
         apps.find(_.application.id == notablesAppIncompatible.id) must beSome
         val setupApp = apps.find(_.application.id == notablesApp.id)
@@ -261,7 +262,35 @@ class ApplicationsServiceSpec(implicit ee: ExecutionEnv) extends PlaySpecificati
         setup ← service.setup(HatApplication(notablesAppMissing, true, true, true, None, None, None))
       } yield setup
 
-      result must throwA[RuntimeException].await(1, 20.seconds)
+      result must throwA[HatApplicationSetupException].await(1, 20.seconds)
+    }
+  }
+
+  "Application `setup` method for applications with dependencies" should {
+    "Enable plug dependencies" in {
+      val service = application.injector.instanceOf[ApplicationsService]
+      val result = for {
+        app <- service.applicationStatus(notablesAppDebitlessWithPlugDependency.id)
+        setup <- service.setup(app.get)
+        dependency <- service.applicationStatus(plugApp.id)
+      } yield {
+        setup.active must beTrue
+        setup.enabled must beTrue
+        setup.dependenciesEnabled must beSome(true)
+        dependency.get.enabled must beTrue
+      }
+
+      result await (1, 20.seconds)
+    }
+
+    "Return failure for invalid dependencies" in {
+      val service = application.injector.instanceOf[ApplicationsService]
+      val result = for {
+        app <- service.applicationStatus(notablesAppDebitlessWithInvalidDependency.id)
+        setup <- service.setup(app.get)
+      } yield setup
+
+      result must throwA[NoSuchElementException].await(1, 20.seconds) // FIXME: it should not be NoSuchElementException
     }
   }
 

--- a/hat/test/org/hatdex/hat/she/functions/DataFeedDirectMapperSpec.scala
+++ b/hat/test/org/hatdex/hat/she/functions/DataFeedDirectMapperSpec.scala
@@ -77,7 +77,7 @@ class DataFeedDirectMapperSpec extends PlaySpecification with Mockito with DataF
       transformed.source must be equalTo "google"
       transformed.types must contain("event")
       transformed.title.get.text must contain("MadHATTERs Tea Party: The Boston Party")
-      transformed.title.get.subtitle.get must contain("12 December 18:30 - 22:30 EST")
+      transformed.title.get.subtitle.get must contain("12 December 18:30 - 22:30 America/New_York")
       transformed.content.get.text.get must contain("personal data, user accounts, security and value")
     }
 
@@ -87,7 +87,7 @@ class DataFeedDirectMapperSpec extends PlaySpecification with Mockito with DataF
       transformed.source must be equalTo "google"
       transformed.types must contain("event")
       transformed.title.get.text must contain("MadHATTERs Tea Party: The Boston Party")
-      transformed.title.get.subtitle.get must contain("12 December 18:30 - 22:30 EST")
+      transformed.title.get.subtitle.get must contain("12 December 18:30 - 22:30 America/New_York")
       transformed.content.get.text.get must contain("BD call")
       transformed.content.get.text.get must not contain ("<br>")
       transformed.content.get.text.get must not contain ("&nbsp;")


### PR DESCRIPTION
The PR is aimed at supporting the transfer of dependency setup logic from frontend components to the backend application service. Change include:

- addition of dependency setup logic
- exceptions specific to the application setup failure mode
- fixes to the previously failing tests

Notable service behaviour: overall application setup process does not fail if one of the dependencies fail to setup. This might change in the future.