### PR TITLE
DS-618 option for functions execution with full dataset

### DIFF
--- a/hat/app/org/hatdex/hat/she/controllers/FunctionManager.scala
+++ b/hat/app/org/hatdex/hat/she/controllers/FunctionManager.scala
@@ -91,12 +91,12 @@ class FunctionManager @Inject() (
   }
 
   // TODO: ApplicationManage permission being used to authorise function trigger. Consider updating to tool-specific permissions
-  def functionTrigger(function: String, useAll: Option[Boolean]): Action[AnyContent] = SecuredAction(ContainsApplicationRole(Owner(), ApplicationManage(function)) || WithRole(Owner(), Platform())).async { implicit request ⇒
+  def functionTrigger(function: String, useAll: Boolean): Action[AnyContent] = SecuredAction(ContainsApplicationRole(Owner(), ApplicationManage(function)) || WithRole(Owner(), Platform())).async { implicit request ⇒
     logger.debug(s"Trigger function $function")
     functionService.get(function).flatMap { maybeFunction ⇒
       maybeFunction.map {
         case c: FunctionConfiguration if c.status.available && c.status.enabled ⇒
-          functionExecutionDispatcher.trigger(request.dynamicEnvironment.domain, c, useAll.getOrElse(false))(ec)
+          functionExecutionDispatcher.trigger(request.dynamicEnvironment.domain, c, useAll)(ec)
             .map(_ ⇒ Ok(Json.toJson(SuccessResponse("Function Executed"))))
             .recover {
               case e ⇒

--- a/hat/app/org/hatdex/hat/she/controllers/FunctionManager.scala
+++ b/hat/app/org/hatdex/hat/she/controllers/FunctionManager.scala
@@ -91,12 +91,12 @@ class FunctionManager @Inject() (
   }
 
   // TODO: ApplicationManage permission being used to authorise function trigger. Consider updating to tool-specific permissions
-  def functionTrigger(function: String): Action[AnyContent] = SecuredAction(ContainsApplicationRole(Owner(), ApplicationManage(function)) || WithRole(Owner(), Platform())).async { implicit request ⇒
+  def functionTrigger(function: String, useAll: Option[Boolean]): Action[AnyContent] = SecuredAction(ContainsApplicationRole(Owner(), ApplicationManage(function)) || WithRole(Owner(), Platform())).async { implicit request ⇒
     logger.debug(s"Trigger function $function")
     functionService.get(function).flatMap { maybeFunction ⇒
       maybeFunction.map {
         case c: FunctionConfiguration if c.status.available && c.status.enabled ⇒
-          functionExecutionDispatcher.trigger(request.dynamicEnvironment.domain, c)(ec)
+          functionExecutionDispatcher.trigger(request.dynamicEnvironment.domain, c, useAll.getOrElse(false))(ec)
             .map(_ ⇒ Ok(Json.toJson(SuccessResponse("Function Executed"))))
             .recover {
               case e ⇒

--- a/hat/app/org/hatdex/hat/she/service/FunctionExecutionDispatcher.scala
+++ b/hat/app/org/hatdex/hat/she/service/FunctionExecutionDispatcher.scala
@@ -129,12 +129,12 @@ class FunctionExecutionTriggerHandler @Inject() (
   logger.info("Function Executor Trigger Handler starting")
   dataEventBus.subscribe(triggerStream, classOf[HatDataEventBus.DataCreatedEvent])
 
-  def trigger(hat: String, conf: FunctionConfiguration)(implicit ec: ExecutionContext): Future[Done] = {
+  def trigger(hat: String, conf: FunctionConfiguration, useAll: Boolean = false)(implicit ec: ExecutionContext): Future[Done] = {
     logger.info(s"[$hat] Triggered function ${conf.id}")
     hatServerProvider.retrieve(hat)
       .flatMap {
         _.map { hatServer =>
-          functionService.run(conf, conf.status.lastExecution)(hatServer)
+          functionService.run(conf, conf.status.lastExecution, useAll)(hatServer)
             .recover {
               case e => throw SHEFunctionExecutionFailureException(s"$hat function ${conf.id} failed", e)
             }

--- a/hat/app/org/hatdex/hat/she/service/FunctionService.scala
+++ b/hat/app/org/hatdex/hat/she/service/FunctionService.scala
@@ -152,7 +152,6 @@ class FunctionService @Inject() (
           _ ← markExecuting(configuration)
           bundle ← function.bundleFilterByDate(fromDate, untilDate)
           data ← dataService.bundleData(bundle, createdAfter = dataBundleTimeFilter) // Get all bundle data from a specific date until now
-          // data ← dataService.bundleData(bundle, createdAfter = None) // TODO: Terry's comment: Setting createdAfter to None will allow the use case of - Show me the word distribution of my last 100 tweets.
           response ← function.execute(configuration, Request(data, linkRecords = true)) // Execute the function
             .map(removeDuplicateData) // Remove duplicate data in case some records mapped onto the same values when transformed
           // TODO handle cases when function runs for longer and connection to DB needs to be reestablished

--- a/hat/app/org/hatdex/hat/she/service/FunctionService.scala
+++ b/hat/app/org/hatdex/hat/she/service/FunctionService.scala
@@ -134,17 +134,24 @@ class FunctionService @Inject() (
       .map(_.get)
   }
 
-  def run(configuration: FunctionConfiguration, startTime: Option[DateTime])(implicit hatServer: HatServer): Future[Done] = {
+  def run(configuration: FunctionConfiguration, startTime: Option[DateTime], useAll: Boolean)(implicit hatServer: HatServer): Future[Done] = {
     val executionTime = DateTime.now()
     logger.info(s"[${hatServer.domain}] SHE function [${configuration.id}] run @$executionTime (previously $startTime)")
     functionRegistry.get[FunctionExecutable](configuration.id)
       .map { function: FunctionExecutable =>
         val fromDate = startTime.orElse(Some(DateTime.now().minusMonths(6)))
         val untilDate = Some(DateTime.now().plusMonths(3))
+        val dataBundleTimeFilter = if (useAll) {
+          None
+        }
+        else {
+          configuration.status.lastExecution
+        }
+
         val executionResult = for {
           _ ← markExecuting(configuration)
           bundle ← function.bundleFilterByDate(fromDate, untilDate)
-          data ← dataService.bundleData(bundle, createdAfter = configuration.status.lastExecution) // Get all bundle data from a specific date until now
+          data ← dataService.bundleData(bundle, createdAfter = dataBundleTimeFilter) // Get all bundle data from a specific date until now
           // data ← dataService.bundleData(bundle, createdAfter = None) // TODO: Terry's comment: Setting createdAfter to None will allow the use case of - Show me the word distribution of my last 100 tweets.
           response ← function.execute(configuration, Request(data, linkRecords = true)) // Execute the function
             .map(removeDuplicateData) // Remove duplicate data in case some records mapped onto the same values when transformed

--- a/hat/conf/v20.routes
+++ b/hat/conf/v20.routes
@@ -60,6 +60,6 @@ GET           /she/function                                                     
 GET           /she/function/:function                                                        org.hatdex.hat.she.controllers.FunctionManager.functionGet(function: String)
 GET           /she/function/:function/enable                                                 org.hatdex.hat.she.controllers.FunctionManager.functionEnable(function: String)
 GET           /she/function/:function/disable                                                org.hatdex.hat.she.controllers.FunctionManager.functionDisable(function: String)
-GET           /she/function/:function/trigger                                                org.hatdex.hat.she.controllers.FunctionManager.functionTrigger(function: String)
+GET           /she/function/:function/trigger                                                org.hatdex.hat.she.controllers.FunctionManager.functionTrigger(function: String, useAll: Option[Boolean])
 GET           /she/feed                                                                      org.hatdex.hat.she.controllers.FeedGenerator.fullFeed(since: Option[Long], until: Option[Long])
 GET           /she/feed/$endpoint<[0-9a-z-/]+>                                               org.hatdex.hat.she.controllers.FeedGenerator.getFeed(endpoint: String, since: Option[Long], until: Option[Long])

--- a/hat/conf/v20.routes
+++ b/hat/conf/v20.routes
@@ -60,6 +60,6 @@ GET           /she/function                                                     
 GET           /she/function/:function                                                        org.hatdex.hat.she.controllers.FunctionManager.functionGet(function: String)
 GET           /she/function/:function/enable                                                 org.hatdex.hat.she.controllers.FunctionManager.functionEnable(function: String)
 GET           /she/function/:function/disable                                                org.hatdex.hat.she.controllers.FunctionManager.functionDisable(function: String)
-GET           /she/function/:function/trigger                                                org.hatdex.hat.she.controllers.FunctionManager.functionTrigger(function: String, useAll: Option[Boolean])
+GET           /she/function/:function/trigger                                                org.hatdex.hat.she.controllers.FunctionManager.functionTrigger(function: String, useAll: Boolean ?= false)
 GET           /she/feed                                                                      org.hatdex.hat.she.controllers.FeedGenerator.fullFeed(since: Option[Long], until: Option[Long])
 GET           /she/feed/$endpoint<[0-9a-z-/]+>                                               org.hatdex.hat.she.controllers.FeedGenerator.getFeed(endpoint: String, since: Option[Long], until: Option[Long])

--- a/hat/conf/v26.routes
+++ b/hat/conf/v26.routes
@@ -70,7 +70,7 @@ GET           /she/function                                                     
 GET           /she/function/:function                                                        org.hatdex.hat.she.controllers.FunctionManager.functionGet(function: String)
 GET           /she/function/:function/enable                                                 org.hatdex.hat.she.controllers.FunctionManager.functionEnable(function: String)
 GET           /she/function/:function/disable                                                org.hatdex.hat.she.controllers.FunctionManager.functionDisable(function: String)
-GET           /she/function/:function/trigger                                                org.hatdex.hat.she.controllers.FunctionManager.functionTrigger(function: String, useAll: Option[Boolean])
+GET           /she/function/:function/trigger                                                org.hatdex.hat.she.controllers.FunctionManager.functionTrigger(function: String, useAll: Boolean ?= false)
 GET           /she/feed                                                                      org.hatdex.hat.she.controllers.FeedGenerator.fullFeed(since: Option[Long], until: Option[Long])
 GET           /she/feed/$endpoint<[0-9a-z-/]+>                                               org.hatdex.hat.she.controllers.FeedGenerator.getFeed(endpoint: String, since: Option[Long], until: Option[Long])
 

--- a/hat/conf/v26.routes
+++ b/hat/conf/v26.routes
@@ -70,7 +70,7 @@ GET           /she/function                                                     
 GET           /she/function/:function                                                        org.hatdex.hat.she.controllers.FunctionManager.functionGet(function: String)
 GET           /she/function/:function/enable                                                 org.hatdex.hat.she.controllers.FunctionManager.functionEnable(function: String)
 GET           /she/function/:function/disable                                                org.hatdex.hat.she.controllers.FunctionManager.functionDisable(function: String)
-GET           /she/function/:function/trigger                                                org.hatdex.hat.she.controllers.FunctionManager.functionTrigger(function: String)
+GET           /she/function/:function/trigger                                                org.hatdex.hat.she.controllers.FunctionManager.functionTrigger(function: String, useAll: Option[Boolean])
 GET           /she/feed                                                                      org.hatdex.hat.she.controllers.FeedGenerator.fullFeed(since: Option[Long], until: Option[Long])
 GET           /she/feed/$endpoint<[0-9a-z-/]+>                                               org.hatdex.hat.she.controllers.FeedGenerator.getFeed(endpoint: String, since: Option[Long], until: Option[Long])
 

--- a/hat/test/org/hatdex/hat/she/controllers/FunctionManagerSpec.scala
+++ b/hat/test/org/hatdex/hat/she/controllers/FunctionManagerSpec.scala
@@ -201,7 +201,7 @@ class FunctionManagerSpec(implicit ee: ExecutionEnv) extends PlaySpecification w
         .withAuthenticator(owner.loginInfo)
 
       val controller = application.injector.instanceOf[FunctionManager]
-      val result: Future[Result] = Helpers.call(controller.functionTrigger("random-function", None), request)
+      val result: Future[Result] = Helpers.call(controller.functionTrigger("random-function", useAll = false), request)
 
       status(result) must equalTo(NOT_FOUND)
       val message = contentAsJson(result).as[ErrorMessage]
@@ -213,7 +213,7 @@ class FunctionManagerSpec(implicit ee: ExecutionEnv) extends PlaySpecification w
         .withAuthenticator(owner.loginInfo)
 
       val controller = application.injector.instanceOf[FunctionManager]
-      val result: Future[Result] = Helpers.call(controller.functionTrigger(registeredDummyFunctionAvailable.configuration.id, None), request)
+      val result: Future[Result] = Helpers.call(controller.functionTrigger(registeredDummyFunctionAvailable.configuration.id, useAll = false), request)
 
       status(result) must equalTo(BAD_REQUEST)
       val message = contentAsJson(result).as[ErrorMessage]
@@ -228,7 +228,7 @@ class FunctionManagerSpec(implicit ee: ExecutionEnv) extends PlaySpecification w
       val controller = application.injector.instanceOf[FunctionManager]
       val result: Future[Result] = for {
         _ <- service.save(dummyFunctionConfiguration)
-        result <- Helpers.call(controller.functionTrigger("test-dummy-function", None), request)
+        result <- Helpers.call(controller.functionTrigger("test-dummy-function", useAll = false), request)
       } yield result
 
       status(result) must equalTo(BAD_REQUEST)
@@ -254,7 +254,7 @@ class FunctionManagerSpec(implicit ee: ExecutionEnv) extends PlaySpecification w
 
       await(setup)(60.seconds)
 
-      val result = Helpers.call(controller.functionTrigger("data-feed-direct-mapper", None), request)
+      val result = Helpers.call(controller.functionTrigger("data-feed-direct-mapper", useAll = false), request)
       status(result) must equalTo(OK)
       val message = contentAsJson(result).as[SuccessResponse]
       message.message must be equalTo "Function Executed"

--- a/hat/test/org/hatdex/hat/she/controllers/FunctionManagerSpec.scala
+++ b/hat/test/org/hatdex/hat/she/controllers/FunctionManagerSpec.scala
@@ -201,7 +201,7 @@ class FunctionManagerSpec(implicit ee: ExecutionEnv) extends PlaySpecification w
         .withAuthenticator(owner.loginInfo)
 
       val controller = application.injector.instanceOf[FunctionManager]
-      val result: Future[Result] = Helpers.call(controller.functionTrigger("random-function"), request)
+      val result: Future[Result] = Helpers.call(controller.functionTrigger("random-function", None), request)
 
       status(result) must equalTo(NOT_FOUND)
       val message = contentAsJson(result).as[ErrorMessage]
@@ -213,7 +213,7 @@ class FunctionManagerSpec(implicit ee: ExecutionEnv) extends PlaySpecification w
         .withAuthenticator(owner.loginInfo)
 
       val controller = application.injector.instanceOf[FunctionManager]
-      val result: Future[Result] = Helpers.call(controller.functionTrigger(registeredDummyFunctionAvailable.configuration.id), request)
+      val result: Future[Result] = Helpers.call(controller.functionTrigger(registeredDummyFunctionAvailable.configuration.id, None), request)
 
       status(result) must equalTo(BAD_REQUEST)
       val message = contentAsJson(result).as[ErrorMessage]
@@ -228,7 +228,7 @@ class FunctionManagerSpec(implicit ee: ExecutionEnv) extends PlaySpecification w
       val controller = application.injector.instanceOf[FunctionManager]
       val result: Future[Result] = for {
         _ <- service.save(dummyFunctionConfiguration)
-        result <- Helpers.call(controller.functionTrigger("test-dummy-function"), request)
+        result <- Helpers.call(controller.functionTrigger("test-dummy-function", None), request)
       } yield result
 
       status(result) must equalTo(BAD_REQUEST)
@@ -254,7 +254,7 @@ class FunctionManagerSpec(implicit ee: ExecutionEnv) extends PlaySpecification w
 
       await(setup)(60.seconds)
 
-      val result = Helpers.call(controller.functionTrigger("data-feed-direct-mapper"), request)
+      val result = Helpers.call(controller.functionTrigger("data-feed-direct-mapper", None), request)
       status(result) must equalTo(OK)
       val message = contentAsJson(result).as[SuccessResponse]
       message.message must be equalTo "Function Executed"

--- a/hat/test/org/hatdex/hat/she/service/FunctionServiceSpec.scala
+++ b/hat/test/org/hatdex/hat/she/service/FunctionServiceSpec.scala
@@ -205,7 +205,7 @@ class FunctionServiceSpec(implicit ee: ExecutionEnv) extends PlaySpecification w
 
       val executed = for {
         _ <- dataService.saveData(owner.userId, records)
-        _ <- service.run(registeredFunction.configuration, None)
+        _ <- service.run(registeredFunction.configuration, None, useAll = false)
         data <- dataService.propertyData(
           Seq(EndpointQuery(s"${registeredFunction.namespace}/${registeredFunction.endpoint}", None, None, None)),
           None, orderingDescending = false, 0, None)
@@ -222,7 +222,7 @@ class FunctionServiceSpec(implicit ee: ExecutionEnv) extends PlaySpecification w
 
     "Throw an error if no function matching the name is available" in {
       val service = application.injector.instanceOf[FunctionService]
-      service.run(dummyFunctionConfiguration, None) must throwA[RuntimeException].await(1, 30.seconds)
+      service.run(dummyFunctionConfiguration, None, useAll = false) must throwA[RuntimeException].await(1, 30.seconds)
     }
   }
 


### PR DESCRIPTION
**Original behaviour**

By default, on every execution the SHE function would only use data records that were added _after_ previous execution.

**Behaviour in this PR**

Default behaviour remains the same. However, the PR adds an optional query parameter to the function trigger endpoint. The caller can specify whether to use only the newly added data, or the whole available dataset.

Example API request:
```
GET https://my.hat.org/api/v2.6/she/function/:function/trigger?useAll=true
```