### PR TITLE
DSE 355 configurable dex address

### DIFF
--- a/hat/conf/application.conf
+++ b/hat/conf/application.conf
@@ -222,6 +222,7 @@ exchange {
   admin = ["systems@hatdex.org"]
   admin = [${?HAT_ADMIN_EMAIL}]
   address = "dex.hubofallthings.com"
+  address = ${?DEX_ADDRESS}
   scheme = "https://"
   retryLimit = 10
   retryTime = 30 minutes


### PR DESCRIPTION
The update adds an option to override the hard-coded Dex host (dex.hubofallthings.com) with a custom host specified in the environment variable.